### PR TITLE
Get lager event handlers from gen_event

### DIFF
--- a/src/couch_log_lager.erl
+++ b/src/couch_log_lager.erl
@@ -64,9 +64,9 @@ emergency(Fmt, Args) ->
 
 -spec set_level(atom()) -> ok.
 set_level(Level) ->
-    {ok, Handlers} = application:get_env(lager, handlers),
-    lists:foreach(fun({Handler, _}) ->
-        lager:set_loglevel(Handler, Level)
+    Handlers = gen_event:which_handlers(lager_event),
+    lists:foreach(fun(Handler) ->
+        ok = lager:set_loglevel(Handler, Level)
     end, Handlers).
 
 


### PR DESCRIPTION
The existing mechanism for getting lager_event's handlers incorrectly uses the data structure returned by application:get_env, which returns a configuration data structure defined in sys.config. The actual lager_event handler list is obtained directly from gen_event.

COUCHDB-2970
